### PR TITLE
Version 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This Discord bot displays the current [cloud] status that shows if the [cloud] r
 
 - Displays the [cloud] status in the server member list
   - **🟢 Online** when [cloud] is open
+  - **🟡 Idle** when [cloud] is about to close
   - **⛔️ Do Not Disturb** when [cloud] is closed
 - `/status` command to check the current status
 - `/togglestatus` command to toggle the status (for admins only)
+- `/winddown` command to indicate that [cloud] will close soon (for admins only)
 
 ## Roadmap
 

--- a/index.js
+++ b/index.js
@@ -70,8 +70,8 @@ client.once('ready', async () => {
 
 	// Iterate over guild commands and set permissions
 	for (const guildCommand of guildCommands) {
-		// Set permissions for the `/togglestatus` command
-		if (guildCommand.name === 'togglestatus') {
+		// Set permissions for the `/togglestatus` and `/winddown` commands
+		if (guildCommand.name === 'togglestatus' || guildCommand.name === 'winddown') {
 			const command = await client.guilds.cache.get(guildID)?.commands.fetch(guildCommand.id);
 
 			console.log(command);
@@ -89,11 +89,17 @@ client.once('ready', async () => {
 	}
 
 	// Initially set the bot presence according to the current [cloud] status
-	setPresence(status.isOpen);
+	setOpenPresence(status.isOpen);
+	setWindDownPresence(status.windDown);
 
-	// Update the bot presence when the [cloud] status changes
-	statusUpdate.on('update', isOpen => {
-		setPresence(isOpen);
+	// Update the bot presence when [cloud] status changes
+	statusUpdate.on('updateStatus', isOpen => {
+		setOpenPresence(isOpen);
+	});
+
+	// Update the bot presence when [cloud] status "Wind Down" changed
+	statusUpdate.on('updateWindDown', windDown => {
+		setWindDownPresence(windDown);
 	});
 });
 
@@ -113,13 +119,23 @@ client.on('interactionCreate', async interaction => {
 	}
 });
 
-// Set the bot presence
-function setPresence(isOpen) {
+// Set the bot presence for [cloud] status
+function setOpenPresence(isOpen) {
 	if (isOpen) {
 		client.user.setStatus('online');
 	}
 	else {
 		client.user.setStatus('dnd');
+	}
+}
+
+// Set the bot presence for [cloud] status "Wind Down"
+function setWindDownPresence(windDown) {
+	if (windDown) {
+		client.user.setStatus('idle');
+	}
+	else {
+		client.user.setStatus(status.isOpen ? 'online' : 'dnd');
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ const commandFileDir = './src/commands';
 
 dotenv.config();
 
+// Log the program environment
+console.log(`Starting in ${process.env.NODE_ENV} environment`);
+
 // Initialize discord.js client
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node .",
+    "dev": "NODE_ENV=development node .",
     "lint": "eslint ."
   },
   "keywords": [

--- a/src/cloudStatus.js
+++ b/src/cloudStatus.js
@@ -2,20 +2,40 @@ const statusUpdate = require('./statusUpdate.js');
 
 class CloudStatus {
 	constructor() {
-		// Set initial value
+		// Set initial values
 		this.isOpen = false;
+		this.windDown = false;
 	}
 
 	updateStatus(state) {
 		this.isOpen = state;
 
-		// Emit an event to notify that the [cloud] status changed
-		statusUpdate.emit('update', this.isOpen);
+		// Emit an event to notify that [cloud] status changed
+		statusUpdate.emit('updateStatus', this.isOpen);
+	}
+
+	updateWindDown(state) {
+		this.windDown = state;
+
+		// Emit an event to notify that [cloud] status "Wind Down" changed
+		statusUpdate.emit('updateWindDown', this.windDown);
 	}
 
 	toggleStatus() {
-		statusUpdate.emit('toggle');
+		statusUpdate.emit('toggleStatus');
 	}
+
+	enableWindDown() {
+		statusUpdate.emit('enableWindDown');
+	}
+}
+
+let collection = 'status';
+const doc = 'cloud_status';
+
+// Use test collection for development environment
+if (process.env.NODE_ENV === 'development') {
+	collection = 'statusTest';
 }
 
 const admin = require('firebase-admin');
@@ -36,24 +56,45 @@ admin.initializeApp({
 const database = admin.firestore();
 
 // Get [cloud] status document in Firestore and observe it
-const statusDoc = database.collection('status').doc('cloud_status');
+const statusDoc = database.collection(collection).doc(doc);
+
 statusDoc.onSnapshot(snapshot => {
 	console.log('Received status update');
 
 	// Update local [cloud] status
 	status.updateStatus(snapshot.data().open);
+
+	// Update local "Wind Down" state
+	status.updateWindDown(snapshot.data().windDown);
 }, error => {
 	console.error(`Encountered error: ${error}`);
 });
 
 // Toggle [cloud] status
-statusUpdate.on('toggle', async () => {
+statusUpdate.on('toggleStatus', async () => {
+	// Disable "Wind Down" when [cloud] gets closed
+	if (status.isOpen) {
+		statusDoc.update({
+			windDown: false,
+		});
+
+		console.log('Disabled [cloud] status “Wind Down”');
+	}
+
 	// Toggle [cloud] status in Firestore
 	statusDoc.update({
 		open: !status.isOpen,
 	});
 
 	console.log('Toggled the [cloud] status');
+});
+
+// Enable [cloud] status "Wind Down"
+statusUpdate.on('enableWindDown', async () => {
+	// Enable [cloud] status "Wind Down" in Firestore
+	statusDoc.update({
+		windDown: true,
+	});
 });
 
 // Export class instance

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1,7 +1,10 @@
 // Get [cloud] status
 const status = require('../cloudStatus.js');
 
-// Export command '/status'
+// Import helper to conviniently detect development environment
+const isDev = require('../isDev');
+
+// Export command `/status`
 module.exports = {
 	data: {
 		name: 'status',
@@ -9,12 +12,27 @@ module.exports = {
 	},
 	async execute(interaction) {
 		const messageStaticPart = ' [cloud] is ';
+		const devIndicatorMessage = ' [Development Mode]';
 
 		if (status.isOpen) {
-			await interaction.reply('🟢' + messageStaticPart + 'open');
+			if (status.windDown) {
+				let reply = '🟡 [cloud] closes soon';
+				if (isDev) reply += devIndicatorMessage;
+
+				await interaction.reply(reply);
+			}
+			else {
+				let reply = '🟢' + messageStaticPart + 'open';
+				if (isDev) reply += devIndicatorMessage;
+
+				await interaction.reply(reply);
+			}
 		}
 		else {
-			await interaction.reply('🔴' + messageStaticPart + 'closed');
+			let reply = '🔴' + messageStaticPart + 'closed';
+			if (isDev) reply += devIndicatorMessage;
+
+			await interaction.reply(reply);
 		}
 	},
 };

--- a/src/commands/toggleStatus.js
+++ b/src/commands/toggleStatus.js
@@ -1,7 +1,10 @@
+// Import helper to conviniently detect development environment
+const isDev = require('../isDev');
+
 // Get [cloud] status
 const status = require('../cloudStatus.js');
 
-// Export command '/togglestatus'
+// Export command `/togglestatus`
 module.exports = {
 	data: {
 		name: 'togglestatus',
@@ -14,13 +17,20 @@ module.exports = {
 
 		// Confirm the action and reply with the new [cloud] status
 		const messageStaticPart = ' [cloud] is now ';
+		const devIndicatorMessage = ' [Development Mode]';
 
 		// HACK: Assume that the toggle operation succeeded and `status.isOpen` is now its opposite
 		if (!status.isOpen) {
-			await interaction.reply('🟢' + messageStaticPart + 'open!');
+			let reply = '🟢' + messageStaticPart + 'open!';
+			if (isDev) reply += devIndicatorMessage;
+
+			await interaction.reply(reply);
 		}
 		else {
-			await interaction.reply('🔴' + messageStaticPart + 'closed!');
+			let reply = '🔴' + messageStaticPart + 'closed!';
+			if (isDev) reply += devIndicatorMessage;
+
+			await interaction.reply(reply);
 		}
 	},
 };

--- a/src/commands/windDown.js
+++ b/src/commands/windDown.js
@@ -1,0 +1,33 @@
+// Import helper to conviniently detect development environment
+const isDev = require('../isDev');
+
+// Get [cloud] status
+const status = require('../cloudStatus.js');
+
+// Export command `/winddown`
+module.exports = {
+	data: {
+		name: 'winddown',
+		description: 'Indicates that [cloud] is about to close',
+		default_permission: false,
+	},
+	async execute(interaction) {
+		const devIndicatorMessage = ' [Development Mode]';
+
+		// Enable [cloud] status "Wind Down" when [cloud] is open
+		if (status.isOpen) {
+			status.enableWindDown();
+
+			let reply = '🟡 [cloud] will close soon';
+			if (isDev) reply += devIndicatorMessage;
+
+			await interaction.reply(reply);
+		}
+		else {
+			let reply = '❌ [cloud] is already closed';
+			if (isDev) reply += devIndicatorMessage;
+
+			await interaction.reply(reply);
+		}
+	},
+};

--- a/src/isDev.js
+++ b/src/isDev.js
@@ -1,0 +1,5 @@
+let isDev = false;
+
+if (process.env.NODE_ENV === 'development') isDev = true;
+
+module.exports = isDev;


### PR DESCRIPTION
- Adds “Wind Down” feature to [cloud] status which indicates if [cloud] is about to close
- Adds `/winddown` command to enable “Wind Down” (for admins only)
- Uses separate test data on Google Firestore if the bot is launched in the development environment
- Adds a developer mode message to command replies

Closes #15 